### PR TITLE
Add --no-metadata, --no-pre-release, --no-build flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ To discard [pre-release](https://semver.org/#spec-item-9) and/or [build metadata
 | ------------------ | ---------------------------------------- | ---------------------------------------- |
 | `--no-metadata`    | Discards pre-release and build metadata. | `v1.0.0-alpha+build.f902daf` -> `v1.0.0` |
 | `--no-pre-release` | Discards pre-release metadata.           | `v1.0.0-alpha` -> `v1.0.0`               |
-| `--no-build`       | Discards build metadata.                 | `v1.0.0build.f902daf` -> `v1.0.0`        |
+| `--no-build`       | Discards build metadata.                 | `v1.0.0+build.f902daf` -> `v1.0.0`       |
 
 ## Creating tags
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,13 @@ v1.2.4
 
 ## Discarding pre-release and build metadata
 
-To discard [pre-release](https://semver.org/#spec-item-9) and [build metadata](https://semver.org/#spec-item-10) information just run the command of your choice with the `--only-core-version` flag.
+To discard [pre-release](https://semver.org/#spec-item-9) and/or [build metadata](https://semver.org/#spec-item-10) information you can run your comman dof choice with the following flags:
+
+| Flag               | Description                              | Example                                  |
+| ------------------ | ---------------------------------------- | ---------------------------------------- |
+| `--no-metadata`    | Discards pre-release and build metadata. | `v1.0.0-alpha+build.f902daf` -> `v1.0.0` |
+| `--no-pre-release` | Discards pre-release metadata.           | `v1.0.0-alpha` -> `v1.0.0`               |
+| `--no-build`       | Discards build metadata.                 | `v1.0.0build.f902daf` -> `v1.0.0`        |
 
 ## Creating tags
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ v1.3.0
 
 #### Commit messages vs what they do:
 
-| Commit message | Tag increase |
-|---|---|
-| `fix: fixed something` | Patch |
-| `feat: added new button to do X` | Minor |
-| `fix: fixed thing xyz`<br><br>`BREAKING CHANGE: this will break users because of blah` | Major |
-| `fix!: fixed something` | Major |
-| `feat!: added blah` | Major |
-| `chore: foo` | Nothing |
+| Commit message                                                                         | Tag increase |
+| -------------------------------------------------------------------------------------- | ------------ |
+| `fix: fixed something`                                                                 | Patch        |
+| `feat: added new button to do X`                                                       | Minor        |
+| `fix: fixed thing xyz`<br><br>`BREAKING CHANGE: this will break users because of blah` | Major        |
+| `fix!: fixed something`                                                                | Major        |
+| `feat!: added blah`                                                                    | Major        |
+| `chore: foo`                                                                           | Nothing      |
 
 ### `svu current`
 
@@ -72,6 +72,10 @@ Increases the patch of the latest tag and prints it.
 $ svu patch
 v1.2.4
 ```
+
+## Discarding pre-release and build metadata
+
+To discard [pre-release](https://semver.org/#spec-item-9) and [build metadata](https://semver.org/#spec-item-10) information just run the command of your choice with the `--only-core-version` flag.
 
 ## Creating tags
 

--- a/main.go
+++ b/main.go
@@ -12,14 +12,16 @@ import (
 )
 
 var (
-	version         = "dev"
-	app             = kingpin.New("svu", "semantic version util")
-	nextCmd         = app.Command("next", "prints the next version based on the git log").Alias("n").Default()
-	majorCmd        = app.Command("major", "new major version")
-	minorCmd        = app.Command("minor", "new minor version").Alias("m")
-	patchCmd        = app.Command("patch", "new patch version").Alias("p")
-	currentCmd      = app.Command("current", "prints current version").Alias("c")
-	onlyCoreVersion = app.Flag("only-core-version", "discards pre-release and build metadata").Bool()
+	version      = "dev"
+	app          = kingpin.New("svu", "semantic version util")
+	nextCmd      = app.Command("next", "prints the next version based on the git log").Alias("n").Default()
+	majorCmd     = app.Command("major", "new major version")
+	minorCmd     = app.Command("minor", "new minor version").Alias("m")
+	patchCmd     = app.Command("patch", "new patch version").Alias("p")
+	currentCmd   = app.Command("current", "prints current version").Alias("c")
+	noMetadata   = app.Flag("no-metadata", "discards pre-release and build metadata").Default("false").Bool()
+	noPreRelease = app.Flag("no-pre-release", "discards pre-release metadata").Default("false").Bool()
+	noBuild      = app.Flag("no-build", "discards build metadata").Default("false").Bool()
 )
 
 func main() {
@@ -35,8 +37,16 @@ func main() {
 	current, err := semver.NewVersion(tag)
 	app.FatalIfError(err, "version %s is not semantic", tag)
 
-	if *onlyCoreVersion {
+	if *noMetadata {
 		current.SetPrerelease("")
+		current.SetMetadata("")
+	}
+
+	if *noPreRelease {
+		current.SetPrerelease("")
+	}
+
+	if *noBuild {
 		current.SetMetadata("")
 	}
 

--- a/main.go
+++ b/main.go
@@ -88,10 +88,7 @@ func unsetBuild(current *semver.Version) *semver.Version {
 }
 
 func unsetMetadata(current *semver.Version) *semver.Version {
-	newV := unsetBuild(current)
-	newV = unsetPreRelease(newV)
-
-	return newV
+	return unsetBuild(unsetPreRelease(current))
 }
 
 func findNext(current *semver.Version, tag string) semver.Version {

--- a/main.go
+++ b/main.go
@@ -12,16 +12,16 @@ import (
 )
 
 var (
-	version      = "dev"
-	app          = kingpin.New("svu", "semantic version util")
-	nextCmd      = app.Command("next", "prints the next version based on the git log").Alias("n").Default()
-	majorCmd     = app.Command("major", "new major version")
-	minorCmd     = app.Command("minor", "new minor version").Alias("m")
-	patchCmd     = app.Command("patch", "new patch version").Alias("p")
-	currentCmd   = app.Command("current", "prints current version").Alias("c")
-	noMetadata   = app.Flag("no-metadata", "discards pre-release and build metadata").Bool()
-	noPreRelease = app.Flag("no-pre-release", "discards pre-release metadata").Bool()
-	noBuild      = app.Flag("no-build", "discards build metadata").Bool()
+	version    = "dev"
+	app        = kingpin.New("svu", "semantic version util")
+	nextCmd    = app.Command("next", "prints the next version based on the git log").Alias("n").Default()
+	majorCmd   = app.Command("major", "new major version")
+	minorCmd   = app.Command("minor", "new minor version").Alias("m")
+	patchCmd   = app.Command("patch", "new patch version").Alias("p")
+	currentCmd = app.Command("current", "prints current version").Alias("c")
+	metadata   = app.Flag("metadata", "discards pre-release and build metadata if set to false").Default("true").Bool()
+	preRelease = app.Flag("pre-release", "discards pre-release metadata if set to false").Default("true").Bool()
+	build      = app.Flag("build", "discards build metadata if set to false").Default("true").Bool()
 )
 
 func main() {
@@ -37,15 +37,15 @@ func main() {
 	current, err := semver.NewVersion(tag)
 	app.FatalIfError(err, "version %s is not semantic", tag)
 
-	if *noMetadata {
+	if !*metadata {
 		current = unsetMetadata(current)
 	}
 
-	if *noPreRelease {
+	if !*preRelease {
 		current = unsetPreRelease(current)
 	}
 
-	if *noBuild {
+	if !*build {
 		current = unsetBuild(current)
 	}
 

--- a/main.go
+++ b/main.go
@@ -12,13 +12,14 @@ import (
 )
 
 var (
-	version    = "dev"
-	app        = kingpin.New("svu", "semantic version util")
-	nextCmd    = app.Command("next", "prints the next version based on the git log").Alias("n").Default()
-	majorCmd   = app.Command("major", "new major version")
-	minorCmd   = app.Command("minor", "new minor version").Alias("m")
-	patchCmd   = app.Command("patch", "new patch version").Alias("p")
-	currentCmd = app.Command("current", "prints current version").Alias("c")
+	version         = "dev"
+	app             = kingpin.New("svu", "semantic version util")
+	nextCmd         = app.Command("next", "prints the next version based on the git log").Alias("n").Default()
+	majorCmd        = app.Command("major", "new major version")
+	minorCmd        = app.Command("minor", "new minor version").Alias("m")
+	patchCmd        = app.Command("patch", "new patch version").Alias("p")
+	currentCmd      = app.Command("current", "prints current version").Alias("c")
+	onlyCoreVersion = app.Flag("only-core-version", "discards pre-release and build metadata").Bool()
 )
 
 func main() {
@@ -33,6 +34,11 @@ func main() {
 
 	current, err := semver.NewVersion(tag)
 	app.FatalIfError(err, "version %s is not semantic", tag)
+
+	if *onlyCoreVersion {
+		current.SetPrerelease("")
+		current.SetMetadata("")
+	}
 
 	var prefix string
 	if strings.HasPrefix(tag, "v") {


### PR DESCRIPTION
This PR introduces flags to discard pre-release and/or build metadata information:

| Flag               | Description                              | Example                                  |
| ------------------ | ---------------------------------------- | ---------------------------------------- |
| `--no-metadata`    | Discards pre-release and build metadata. | `v1.0.0-alpha+build.f902daf` -> `v1.0.0` |
| `--no-pre-release` | Discards pre-release metadata.           | `v1.0.0-alpha` -> `v1.0.0`               |
| `--no-build`       | Discards build metadata.                 | `v1.0.0+build.f902daf` -> `v1.0.0`        |
