### PR TITLE
Add --tag-mode flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ $ svu patch
 v1.2.4
 ```
 
+## Tag mode
+
+By default `svu` will get the latest tag from the current branch. Using the `--tag-mode` flag this behaviour can be altered:
+
+| Flag                        | Description                          | Git command used under the hood                            |
+| --------------------------- | ------------------------------------ | ---------------------------------------------------------- |
+| `--tag-mode current-branch` | Get latest tag from current branch.  | `git describe --tags --abbrev=0`                           |
+| `--tag-mode all-branches`   | Get latest tag accross all branches. | `git describe --tags $(git rev-list --tags --max-count=1)` |
+
 ## Discarding pre-release and build metadata
 
 To discard [pre-release](https://semver.org/#spec-item-9) and/or [build metadata](https://semver.org/#spec-item-10) information you can run your comman dof choice with the following flags:

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ var (
 	metadata   = app.Flag("metadata", "discards pre-release and build metadata if set to false").Default("true").Bool()
 	preRelease = app.Flag("pre-release", "discards pre-release metadata if set to false").Default("true").Bool()
 	build      = app.Flag("build", "discards build metadata if set to false").Default("true").Bool()
+	tagMode    = app.Flag("tag-mode", "determines if latest tag of the current or all branches will be used").Default("current-branch").Enum("current-branch", "all-branches")
 )
 
 func main() {
@@ -111,6 +112,15 @@ func findNext(current *semver.Version, tag string) semver.Version {
 }
 
 func getTag() (string, error) {
+	if *tagMode == "all-branches" {
+		tagHash, err := git.Clean(git.Run("rev-list", "--tags", "--max-count=1"))
+		if err != nil {
+			return "", err
+		}
+
+		return git.Clean(git.Run("describe", "--tags", tagHash))
+	}
+
 	return git.Clean(git.Run("describe", "--tags", "--abbrev=0"))
 }
 


### PR DESCRIPTION
By default `svu` will get the latest tag from the current branch. Using the `--tag-mode` flag this behaviour can be altered:

| Flag                        | Description                          | Git command used under the hood                            |
| --------------------------- | ------------------------------------ | ---------------------------------------------------------- |
| `--tag-mode current-branch` | Get latest tag from current branch.  | `git describe --tags --abbrev=0`                           |
| `--tag-mode all-branches`   | Get latest tag accross all branches. | `git describe --tags $(git rev-list --tags --max-count=1)` |
