### PR TITLE
fix: add whitespace before colon(:)

### DIFF
--- a/main.go
+++ b/main.go
@@ -72,9 +72,9 @@ func main() {
 }
 
 var breaking = regexp.MustCompile("(?im).*breaking change:.*")
-var breakingBang = regexp.MustCompile("(?im).*(feat|fix)(\\(.*\\))?!:.*")
-var feature = regexp.MustCompile("(?im).*feat(\\(.*\\))?:.*")
-var patch = regexp.MustCompile("(?im).*fix(\\(.*\\))?:.*")
+var breakingBang = regexp.MustCompile("(?im).*(feat|fix)(\\(.*\\))?!\\s*:.*")
+var feature = regexp.MustCompile("(?im).*feat(\\(.*\\))?\\s*:.*")
+var patch = regexp.MustCompile("(?im).*fix(\\(.*\\))?\\s*:.*")
 
 func unsetPreRelease(current *semver.Version) *semver.Version {
 	newV, _ := current.SetPrerelease("")


### PR DESCRIPTION
- parse `fix : blah`, `feat : blah` , `feat! : blah`