### PR TITLE
fix: make sure "svu next" at least yields a patch release

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ func findNext(current *semver.Version, tag string) semver.Version {
 		return current.IncPatch()
 	}
 
-	return *current
+	return current.IncPatch()
 }
 
 func getTag() (string, error) {


### PR DESCRIPTION
This PR makes sure that running `svu next` at least yields a patch release.