### PR TITLE
feat: tag pattern matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,16 @@ To discard [pre-release](https://semver.org/#spec-item-9) and/or [build metadata
 
 Setting the `--force-patch-increment` flag forces a patch version increment regardless of the commit message content.
 
+## Pattern matching
+
+By default `svu` will get the latest tag, but if you are using more than just version tags you might want `svu` to just look at tags matching a specific pattern. To do that you can set the `--pattern` flag.   
+```sh
+$ svu
+svu: error: tag "latest" is not semantic: Invalid Semantic Version
+$ svu --pattern="v*"
+v1.4.0
+```
+
 ## Creating tags
 
 The idea is that `svu` will just print things, so its safe to run at any time.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ By default `svu` will get the latest tag from the current branch. Using the `--t
 
 ## Discarding pre-release and build metadata
 
-To discard [pre-release](https://semver.org/#spec-item-9) and/or [build metadata](https://semver.org/#spec-item-10) information you can run your comman dof choice with the following flags:
+To discard [pre-release](https://semver.org/#spec-item-9) and/or [build metadata](https://semver.org/#spec-item-10) information you can run your command of choice with the following flags:
 
 | Flag               | Description                              | Example                                  |
 | ------------------ | ---------------------------------------- | ---------------------------------------- |

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/caarlos0/svu
+module github.com/ionDynamics/svu
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ionDynamics/svu
+module github.com/caarlos0/svu
 
 go 1.15
 

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/alecthomas/kingpin"
-	"github.com/caarlos0/svu/internal/git"
+	"github.com/ionDynamics/svu/internal/git"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/alecthomas/kingpin"
-	"github.com/ionDynamics/svu/internal/git"
+	"github.com/caarlos0/svu/internal/git"
 )
 
 var (


### PR DESCRIPTION
We are using more than just version tags in our repos and as `svu` is currently using the latest tag for its calculations it rightfully rejects some of our tags (e.g. `stage`) for being non-semantic.

This PR adds a `--pattern` flag to solve this challenge.