### PR TITLE
feat: add --strip-prefix flag to remove the 'v' from the output version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 dist
+svu
+svu.exe

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ By default `svu` will get the latest tag from the current branch. Using the `--t
 | Flag                        | Description                          | Git command used under the hood                            |
 | --------------------------- | ------------------------------------ | ---------------------------------------------------------- |
 | `--tag-mode current-branch` | Get latest tag from current branch.  | `git describe --tags --abbrev=0`                           |
-| `--tag-mode all-branches`   | Get latest tag accross all branches. | `git describe --tags $(git rev-list --tags --max-count=1)` |
+| `--tag-mode all-branches`   | Get latest tag across all branches. | `git describe --tags $(git rev-list --tags --max-count=1)` |
 
 ## Discarding pre-release and build metadata
 
@@ -91,6 +91,10 @@ To discard [pre-release](https://semver.org/#spec-item-9) and/or [build metadata
 | `--no-metadata`    | Discards pre-release and build metadata. | `v1.0.0-alpha+build.f902daf` -> `v1.0.0` |
 | `--no-pre-release` | Discards pre-release metadata.           | `v1.0.0-alpha` -> `v1.0.0`               |
 | `--no-build`       | Discards build metadata.                 | `v1.0.0+build.f902daf` -> `v1.0.0`       |
+
+## Stripping the tag prefix 
+
+`--strip-prefix` removes any `v` prefix from the version output.  For example, `v1.2.3` would be output as `1.2.3`
 
 ## Force patch version increment
 

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ var (
 	metadata            = app.Flag("metadata", "discards pre-release and build metadata if set to false").Default("true").Bool()
 	preRelease          = app.Flag("pre-release", "discards pre-release metadata if set to false").Default("true").Bool()
 	build               = app.Flag("build", "discards build metadata if set to false").Default("true").Bool()
+	stripPrefix         = app.Flag("strip-prefix", "strips the prefix from the tag").Default("false").Bool()
 	tagMode             = app.Flag("tag-mode", "determines if latest tag of the current or all branches will be used").Default("current-branch").Enum("current-branch", "all-branches")
 	forcePatchIncrement = nextCmd.Flag("force-patch-increment", "forces a patch version increment regardless of the commit message content").Default("false").Bool()
 )
@@ -51,11 +52,6 @@ func main() {
 		current = unsetBuild(current)
 	}
 
-	var prefix string
-	if strings.HasPrefix(tag, "v") {
-		prefix = "v"
-	}
-
 	var result semver.Version
 	switch cmd {
 	case nextCmd.FullCommand():
@@ -69,7 +65,15 @@ func main() {
 	case currentCmd.FullCommand():
 		result = *current
 	}
-	fmt.Printf("%s%s\n", prefix, result.String())
+	fmt.Println(getVersion(tag, result.String(), *stripPrefix))
+}
+
+func getVersion(tag, result string, stripPrefix bool) string {
+	var prefix string
+	if !stripPrefix && strings.HasPrefix(tag, "v") {
+		prefix = "v"
+	}
+	return prefix + result
 }
 
 func unsetPreRelease(current *semver.Version) *semver.Version {

--- a/main_test.go
+++ b/main_test.go
@@ -23,3 +23,15 @@ built by: goreleaser`, buildVersion("v1.2.3", "a123cd", "2021-01-02", "gorelease
 func TestUnsetMetadata(t *testing.T) {
 	is.New(t).True(semver.MustParse("v2.3.4").Equal(unsetMetadata(semver.MustParse("v2.3.4-beta+asd123"))))
 }
+
+func TestStripPrefixReturnsVersionOnly(t *testing.T) {
+	is.New(t).True(getVersion("v2.3.4", "4.5.6", true) == "4.5.6")
+}
+
+func TestStripPrefixWhenNoPrefixReturnsVersionOnly(t *testing.T) {
+	is.New(t).True(getVersion("2.3.4", "4.5.6", true) == "4.5.6")
+}
+
+func TestNoStripPrefixReturnsPrefixAndVersion(t *testing.T) {
+	is.New(t).True(getVersion("v2.3.4", "4.5.6", false) == "v4.5.6")
+}


### PR DESCRIPTION
Add ability to strip the 'v' prefix from the output version. 

This is useful if you  want to use git tags that are prefixed with 'v', but within the build process want the plane next version.

The `main` function has been slightly refactored to allow specific tests of the new feature to be added.


