### PR TITLE
feat: Add --pattern to filter possible tags

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -15,17 +15,28 @@ func IsRepo() bool {
 	return err == nil && strings.TrimSpace(out) == "true"
 }
 
-func DescribeTag(tagMode string) (string, error) {
+func DescribeTag(tagMode string, pattern string) (string, error) {
+	gitDescribe := []string{"describe", "--tags", "--abbrev=0"}
+	if pattern != "" {
+		gitDescribe = append(gitDescribe, "--match", pattern)
+	}
+
 	if tagMode == "all-branches" {
-		tagHash, err := clean(run("rev-list", "--tags", "--max-count=1"))
+		tagsArg := "--tags"
+		if pattern != "" {
+			tagsArg = tagsArg + "=" + pattern
+		}
+
+		tagHash, err := clean(run("rev-list", tagsArg, "--max-count=1"))
 		if err != nil {
 			return "", err
 		}
 
-		return clean(run("describe", "--tags", "--abbrev=0", tagHash))
+		gitDescribe = append(gitDescribe, tagHash)
+		return clean(run(gitDescribe...))
 	}
 
-	return clean(run("describe", "--tags", "--abbrev=0"))
+	return clean(run(gitDescribe...))
 }
 
 func Changelog(tag string) (string, error) {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -30,6 +30,7 @@ func TestDescribeTag(t *testing.T) {
 		tempdir(tb)
 		gitInit(tb)
 		gitCommit(tb, "chore: foobar")
+		gitTag(tb, "pattern-1.2.3")
 		gitCommit(tb, "lalalala")
 		gitTag(tb, "v1.2.3")
 		gitCommit(tb, "chore: aaafoobar")
@@ -45,7 +46,7 @@ func TestDescribeTag(t *testing.T) {
 	t.Run("normal", func(t *testing.T) {
 		setup(t)
 		is := is.New(t)
-		tag, err := DescribeTag("")
+		tag, err := DescribeTag("", "")
 		is.NoErr(err)
 		is.Equal("v1.2.3", tag)
 	})
@@ -53,9 +54,17 @@ func TestDescribeTag(t *testing.T) {
 	t.Run("all-branches", func(t *testing.T) {
 		setup(t)
 		is := is.New(t)
-		tag, err := DescribeTag("all-branches")
+		tag, err := DescribeTag("all-branches", "")
 		is.NoErr(err)
 		is.Equal("v1.2.4", tag)
+	})
+
+	t.Run("pattern", func(t *testing.T) {
+		setup(t)
+		is := is.New(t)
+		tag, err := DescribeTag("", "pattern-*")
+		is.NoErr(err)
+		is.Equal("pattern-1.2.3", tag)
 	})
 }
 

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ var (
 	patchCmd            = app.Command("patch", "new patch version").Alias("p")
 	currentCmd          = app.Command("current", "prints current version").Alias("c")
 	metadata            = app.Flag("metadata", "discards pre-release and build metadata if set to false").Default("true").Bool()
+	pattern             = app.Flag("pattern", "limits calculations to be based on tags matching the given pattern").String()
 	preRelease          = app.Flag("pre-release", "discards pre-release metadata if set to false").Default("true").Bool()
 	build               = app.Flag("build", "discards build metadata if set to false").Default("true").Bool()
 	stripPrefix         = app.Flag("strip-prefix", "strips the prefix from the tag").Default("false").Bool()
@@ -34,7 +35,7 @@ func main() {
 	app.HelpFlag.Short('h')
 	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
 
-	tag, err := git.DescribeTag(*tagMode)
+	tag, err := git.DescribeTag(*tagMode, *pattern)
 	app.FatalIfError(err, "failed to get current tag for repo")
 
 	current, err := semver.NewVersion(tag)


### PR DESCRIPTION
Based on @KEANO89's https://github.com/caarlos0/svu/pull/20. Allows for only considering tags matching a glob.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>