### PR TITLE
feat: support multiple tags at the same commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20210208195552-ff826a37aa15 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/gobwas/glob v0.2.3
 	github.com/matryer/is v1.4.0
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/alecthomas/units v0.0.0-20210208195552-ff826a37aa15/go.mod h1:OMCwj8V
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/matryer/is v1.4.0 h1:sosSmIWwkYITGrxZ25ULNDeKiMNzFSr4V/eqBQP0PeE=
 github.com/matryer/is v1.4.0/go.mod h1:8I/i5uYgLzgsgEloJE1U6xx5HkBQpAZvepWuujKwMRU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -33,6 +33,7 @@ func TestDescribeTag(t *testing.T) {
 		gitTag(tb, "pattern-1.2.3")
 		gitCommit(tb, "lalalala")
 		gitTag(tb, "v1.2.3")
+		gitTag(tb, "v1.2.4") // multiple tags in a single commit
 		gitCommit(tb, "chore: aaafoobar")
 		gitCommit(tb, "docs: asdsad")
 		gitCommit(tb, "fix: fooaaa")
@@ -40,15 +41,15 @@ func TestDescribeTag(t *testing.T) {
 		createBranch(tb, "not-main")
 		gitCommit(tb, "docs: update")
 		gitCommit(tb, "foo: bar")
-		gitTag(tb, "v1.2.4")
+		gitTag(tb, "v1.2.5")
 		switchToBranch(tb, "-")
 	}
 	t.Run("normal", func(t *testing.T) {
 		setup(t)
 		is := is.New(t)
-		tag, err := DescribeTag("", "")
+		tag, err := DescribeTag("current-branch", "")
 		is.NoErr(err)
-		is.Equal("v1.2.3", tag)
+		is.Equal("v1.2.4", tag)
 	})
 
 	t.Run("all-branches", func(t *testing.T) {
@@ -56,13 +57,13 @@ func TestDescribeTag(t *testing.T) {
 		is := is.New(t)
 		tag, err := DescribeTag("all-branches", "")
 		is.NoErr(err)
-		is.Equal("v1.2.4", tag)
+		is.Equal("v1.2.5", tag)
 	})
 
 	t.Run("pattern", func(t *testing.T) {
 		setup(t)
 		is := is.New(t)
-		tag, err := DescribeTag("", "pattern-*")
+		tag, err := DescribeTag("current-branch", "pattern-*")
 		is.NoErr(err)
 		is.Equal("pattern-1.2.3", tag)
 	})


### PR DESCRIPTION
closes https://github.com/caarlos0/svu/issues/37

using `git tag --sort=-version:refname` with `--merged` as well if `current-branch` mode... matching is done using a glob library because `git tag` don't have that option.

on a test repo, it seemed to yield same results

e.g.

```
svu n --strip-prefix --prefix foo/ --pattern 'foo/*'
```

tests were still passing, changed them a bit to test multiple tag against the same commit as well
