### PR TITLE
Feature: Assume an initial version of 0.0.0 if no initial version is found

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -55,7 +55,11 @@ func DescribeTag(tagMode string, pattern string) (string, error) {
 }
 
 func Changelog(tag string) (string, error) {
-	return gitLog(fmt.Sprintf("tags/%s..HEAD", tag))
+	if tag == "" {
+		return gitLog("HEAD")
+	} else {
+		return gitLog(fmt.Sprintf("tags/%s..HEAD", tag))
+	}
 }
 
 func run(args ...string) (string, error) {

--- a/main.go
+++ b/main.go
@@ -36,11 +36,16 @@ func main() {
 	app.HelpFlag.Short('h')
 	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
 
+	var current *semver.Version
 	tag, err := git.DescribeTag(*tagMode, *pattern)
-	app.FatalIfError(err, "failed to get current tag for repo")
-
-	current, err := semver.NewVersion(strings.TrimPrefix(tag, *prefix))
-	app.FatalIfError(err, "version %s is not semantic", tag)
+	app.FatalIfError(err, "issues doing git.DescribeTag on %v", tag)
+	if tag != "" {
+		current, err = semver.NewVersion(strings.TrimPrefix(tag, *prefix))
+		app.FatalIfError(err, "version %s is not semantic", tag)
+	} else {
+		current, err = semver.NewVersion("0.0.0")
+		app.FatalIfError(err, "version %s is not semantic", current)
+	}
 
 	if !*metadata {
 		current = unsetMetadata(current)

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func getCurrentVersion(tag string) (*semver.Version, error) {
 
 }
 
-func getVersion(tag, prefix, result string, stripPrefix bool) string {
+func getVersion(tag, prefix, result, suffix string, stripPrefix bool) string {
 	if stripPrefix {
 		prefix = ""
 	}


### PR DESCRIPTION
Open to changes here for sure, but this is an attempt to get an initial version set up when no version tags have been found. Meant to address #29 