### PR TITLE
feat: add support to filter commit msgs by prefixes

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -77,3 +77,5 @@ func gitLog(refs ...string) (string, error) {
 	args = append(args, refs...)
 	return run(args...)
 }
+
+

--- a/internal/svu/svu.go
+++ b/internal/svu/svu.go
@@ -2,6 +2,7 @@ package svu
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/Masterminds/semver"
 )
@@ -39,4 +40,30 @@ func FindNext(current *semver.Version, forcePatchIncrement bool, log string) sem
 	}
 
 	return *current
+}
+
+func FilterCommits(log string, prefixes []string) string {
+	lines := strings.Split(log, "\n")
+	filtered := make([]string, 0)
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		commitMsgPrefix := strings.Split(line, " ")
+		if len(commitMsgPrefix) < 2 {
+			continue
+		}
+
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(commitMsgPrefix[1], prefix) {
+				filtered = append(filtered, line)
+			}
+		}
+	}
+	if len(filtered) > 0 {
+		return strings.Join(filtered, "\n")
+	} else {
+		return ""
+	}
 }

--- a/internal/svu/svu_test.go
+++ b/internal/svu/svu_test.go
@@ -84,3 +84,47 @@ func TestFindNext(t *testing.T) {
 		is.New(t).True(semver.MustParse(expected).Equal(&next)) // expected and next version should match
 	}
 }
+
+func TestFilterCommits(t *testing.T) {
+	type Input struct {
+		log      string
+		prefixes []string
+	}
+	tests := []struct {
+		name string
+		args Input
+		want string
+	}{
+		{
+			name: "test-filter-happy-path",
+			args: Input{
+				log:      "feat: something\nBREAKING CHANGE: something else",
+				prefixes: []string{"feat:"},
+			},
+			want: "feat: something",
+		},
+		{
+			name: "test-filter-drop-all",
+			args: Input{
+				log:      "feat: something\nBREAKING CHANGE: something else",
+				prefixes: []string{"fix:"},
+			},
+			want: "",
+		},
+		{
+			name: "test-filter-return-all",
+			args: Input{
+				log:      "feat: something\nBREAKING CHANGE: something else",
+				prefixes: []string{"feat:", "BREAKING"},
+			},
+			want: "feat: something\nBREAKING CHANGE: something else",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FilterCommits(tt.args.log, tt.args.prefixes); got != tt.want {
+				t.Errorf("FilterCommits() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/Masterminds/semver"
@@ -38,4 +39,52 @@ func TestNoStripPrefixReturnsPrefixAndVersion(t *testing.T) {
 
 func TestSuffix(t *testing.T) {
 	is.New(t).True(getVersion("v2.3.4", "v", "4.5.6", "dev", false) == "v4.5.6-dev")
+}
+
+func Test_findNextWithSelectCommits(t *testing.T) {
+	type args struct {
+		current        *semver.Version
+		tag            string
+		commitPrefixes []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want semver.Version
+	}{
+		{
+			name: "next-version-with-valid-filter",
+			args: args{
+				current:        semver.MustParse("v1.7.0"),
+				tag:            "v1.7.0",
+				commitPrefixes: []string{"fix"},
+			},
+			want: *semver.MustParse("v1.7.1"),
+		},
+		{
+			name: "next-version-with-valid-filter",
+			args: args{
+				current:        semver.MustParse("v1.7.0"),
+				tag:            "v1.7.0",
+				commitPrefixes: []string{"fix", "feat"},
+			},
+			want: *semver.MustParse("v1.8.0"),
+		},
+		{
+			name: "next-version-with-no-filter",
+			args: args{
+				current:        semver.MustParse("v1.7.0"),
+				tag:            "v1.7.0",
+				commitPrefixes: []string{},
+			},
+			want: *semver.MustParse("v1.8.0"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := findNext(tt.args.current, tt.args.tag, tt.args.commitPrefixes); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("findNextWithSelectCommits() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Some teams do not expect a version bump when a README gets updated with a docs prefix commit or a style change.
To allow that flexibility, this commit introduces a commit-prefix flag that can take multiple values to filter out commit logs before being used to calculate the next semver