### PR TITLE
true prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 dist
 ./svu
 ./svu.exe
+.idea
+.vscode
+

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -3,55 +3,57 @@ package git
 import (
 	"errors"
 	"fmt"
+	"github.com/Masterminds/semver"
 	"os/exec"
 	"strings"
-
-	"github.com/gobwas/glob"
 )
+
+// type tagMode string
+
+const CurrentBranch = "current-branch"
+const AllBranches = "all-branches"
+
+const DefaultSort = "-version:refname"
 
 // copied from goreleaser
 
 // IsRepo returns true if current folder is a git repository
 func IsRepo() bool {
-	out, err := run("rev-parse", "--is-inside-work-tree")
+	out, err := run([]string{"rev-parse", "--is-inside-work-tree"})
 	return err == nil && strings.TrimSpace(out) == "true"
 }
 
-func getAllTags(args ...string) ([]string, error) {
-	tags, err := run(append([]string{"tag", "--sort=-version:refname"}, args...)...)
+func getTags(tagMode, sort, pattern string) ([]string, error) {
+
+	a := []string{"tag"}
+
+	if pattern != "" {
+		a = append(a, pattern)
+	}
+
+	if sort != "" {
+		a = append(a, fmt.Sprintf("--sort=%s", sort))
+	}
+
+	if tagMode == CurrentBranch {
+		a = append(a, "--merged")
+	}
+
+	tags, err := run(a)
 	if err != nil {
 		return nil, err
 	}
 	return strings.Split(tags, "\n"), nil
+
 }
 
-func DescribeTag(tagMode string, pattern string) (string, error) {
-	args := []string{}
-	if tagMode == "current-branch" {
-		args = []string{"--merged"}
-	}
-	tags, err := getAllTags(args...)
+func GetTag(tagMode, pattern string) (string, error) {
+	tags, err := getTags(tagMode, DefaultSort, pattern)
 	if err != nil {
 		return "", err
 	}
 
-	if len(tags) == 0 {
-		return "", nil
-	}
-	if pattern == "" {
-		return tags[0], nil
-	}
-
-	g, err := glob.Compile(pattern)
-	if err != nil {
-		return "", err
-	}
-	for _, tag := range tags {
-		if g.Match(tag) {
-			return tag, nil
-		}
-	}
-	return "", fmt.Errorf("no tags match '%s'", pattern)
+	return tags[0], nil
 }
 
 func Changelog(tag string) (string, error) {
@@ -62,11 +64,9 @@ func Changelog(tag string) (string, error) {
 	}
 }
 
-func run(args ...string) (string, error) {
-	extraArgs := []string{
-		"-c", "log.showSignature=false",
-	}
-	args = append(extraArgs, args...)
+func run(args []string) (string, error) {
+	args = append([]string{"-c", "log.showSignature=false"}, args...)
+	//log.Println("git", strings.Join(args, " "))
 	/* #nosec */
 	cmd := exec.Command("git", args...)
 	bts, err := cmd.CombinedOutput()
@@ -79,5 +79,19 @@ func run(args ...string) (string, error) {
 func gitLog(refs ...string) (string, error) {
 	args := []string{"log", "--no-decorate", "--no-color"}
 	args = append(args, refs...)
-	return run(args...)
+	return run(args)
+}
+
+func GetSemVer(tag, prefix string) (current *semver.Version, err error) {
+	if tag == "" {
+		tag = "0.0.0"
+	}
+
+	if prefix != "" {
+		tag = strings.TrimPrefix(tag, prefix)
+	}
+
+	tag = "v" + tag
+
+	return semver.NewVersion(tag)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/matryer/is"
 )
 
+var ver, _ = semver.NewVersion("v4.5.6")
+
 func TestBuildVersion(t *testing.T) {
 	t.Run("dev", func(t *testing.T) {
 		is.New(t).Equal("svu version dev", buildVersion("dev", "", "", ""))
@@ -25,17 +27,21 @@ func TestUnsetMetadata(t *testing.T) {
 }
 
 func TestStripPrefixReturnsVersionOnly(t *testing.T) {
-	is.New(t).True(getVersion("v2.3.4", "v", "4.5.6", "", true) == "4.5.6")
+	is.New(t).True(getVersion("", ver, "") == "4.5.6")
 }
 
-func TestStripPrefixWhenNoPrefixReturnsVersionOnly(t *testing.T) {
-	is.New(t).True(getVersion("2.3.4", "v", "4.5.6", "", true) == "4.5.6")
+func TestStripPrefixWithVoldemort(t *testing.T) {
+	is.New(t).True(getVersion("voldemort-", ver, "") == "voldemort-4.5.6")
+}
+
+func TestStripPrefixWithVoldemortWithSuffix(t *testing.T) {
+	is.New(t).True(getVersion("voldemort-", ver, "beta+bla") == "voldemort-4.5.6-beta+bla")
 }
 
 func TestNoStripPrefixReturnsPrefixAndVersion(t *testing.T) {
-	is.New(t).True(getVersion("v2.3.4", "v", "4.5.6", "", false) == "v4.5.6")
+	is.New(t).True(getVersion("v", ver, "") == "v4.5.6")
 }
 
 func TestSuffix(t *testing.T) {
-	is.New(t).True(getVersion("v2.3.4", "v", "4.5.6", "dev", false) == "v4.5.6-dev")
+	is.New(t).True(getVersion("v", ver, "dev") == "v4.5.6-dev")
 }


### PR DESCRIPTION
This PR clears semver parsing without `v` . Also it removes `--strip-prefix` and `--pattern` flags.

`--prefix` flag provides `--strip-prefix` functionality. You can set `--prefix=''` for behavior like `--strip-prefix`.
If you need classic `v` you should use `--prefix=v`. I think that will be good as default behavior. 

`--pattern` flag calculate from `--prefix`. 