### PR TITLE
fix: Properly sort pre-release tags

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -18,7 +18,7 @@ func IsRepo() bool {
 }
 
 func getAllTags(args ...string) ([]string, error) {
-	tags, err := run(append([]string{"tag", "--sort=-version:refname"}, args...)...)
+	tags, err := run(append([]string{"-c", "versionsort.suffix=-", "tag", "--sort=-version:refname"}, args...)...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -42,6 +42,7 @@ func TestDescribeTag(t *testing.T) {
 		gitCommit(tb, "docs: update")
 		gitCommit(tb, "foo: bar")
 		gitTag(tb, "v1.2.5")
+		gitTag(tb, "v1.2.5-prerelease")
 		switchToBranch(tb, "-")
 	}
 	t.Run("normal", func(t *testing.T) {


### PR DESCRIPTION
Enable proper sorting of pre-release versions, after corresponding
release version, as per https://github.com/git/git/blob/master/Documentation/config/versionsort.txt:

> By specifying a single suffix in this variable, any tagname containing
that suffix will appear before the corresponding main release.

This effectively implements proper semantic version ordering.
