### PR TITLE
feat: add ability to filter commits by directory

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -54,11 +54,11 @@ func DescribeTag(tagMode string, pattern string) (string, error) {
 	return "", fmt.Errorf("no tags match '%s'", pattern)
 }
 
-func Changelog(tag string) (string, error) {
+func Changelog(tag string, dir string) (string, error) {
 	if tag == "" {
-		return gitLog("HEAD")
+		return gitLog(dir, "HEAD")
 	} else {
-		return gitLog(fmt.Sprintf("tags/%s..HEAD", tag))
+		return gitLog(dir, fmt.Sprintf("tags/%s..HEAD", tag))
 	}
 }
 
@@ -76,8 +76,11 @@ func run(args ...string) (string, error) {
 	return string(bts), nil
 }
 
-func gitLog(refs ...string) (string, error) {
+func gitLog(dir string, refs ...string) (string, error) {
 	args := []string{"log", "--no-decorate", "--no-color"}
 	args = append(args, refs...)
+	if dir != "" {
+		args = append(args, "--", dir)
+	}
 	return run(args...)
 }

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ var (
 	stripPrefix         = app.Flag("strip-prefix", "strips the prefix from the tag").Default("false").Bool()
 	preRelease          = app.Flag("pre-release", "adds a pre-release suffix to the version, without the semver mandatory dash prefix").String()
 	build               = app.Flag("build", "adds a build suffix to the version, without the semver mandatory plug prefix").String()
+	directory           = app.Flag("directory", "specifies directory to filter commit messages by").Default("").String()
 	tagMode             = app.Flag("tag-mode", "determines if latest tag of the current or all branches will be used").Default("current-branch").Enum("current-branch", "all-branches")
 	forcePatchIncrement = nextCmd.Flag("force-patch-increment", "forces a patch version increment regardless of the commit message content").Default("false").Bool()
 )
@@ -71,7 +72,7 @@ func nextVersion(cmd string, current *semver.Version, tag, preRelease, build str
 	var result semver.Version
 	switch cmd {
 	case nextCmd.FullCommand():
-		result = findNext(current, tag)
+		result = findNext(current, tag, *directory)
 	case majorCmd.FullCommand():
 		result = current.IncMajor()
 	case minorCmd.FullCommand():
@@ -103,8 +104,8 @@ func getCurrentVersion(tag string) (*semver.Version, error) {
 	return current, err
 }
 
-func findNext(current *semver.Version, tag string) semver.Version {
-	log, err := git.Changelog(tag)
+func findNext(current *semver.Version, tag string, directory string) semver.Version {
+	log, err := git.Changelog(tag, directory)
 	app.FatalIfError(err, "failed to get changelog")
 
 	return svu.FindNext(current, *forcePatchIncrement, log)


### PR DESCRIPTION
## What
Inspired by #45 and a friends desire to use svu in a monorepo I added a new flag to filter commit messages by directory. This means if you have multiple packages in one repo, combined with the pattern flag you can get the next version number for a specific package.

## Why

Svu searches across the entire git log for commits which is inconvenient when there are multiple packages in one repo (a monorepo). There are a  few ways we could handle this:

* We could filter commit messages by a specific prefix, which requires users to use the prefix in their commits and as commits are multiple lines (#45 ) is more complicated to implement than first seems
* We could add the files to the commit log and search through that, but again is more complicated than it seems
* Use git logs ability to filter by directory (this commit)
* some other idea I've not thought of


