### PR TITLE
feat!: simplify metadata/build api

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -20,22 +20,134 @@ built by: goreleaser`, buildVersion("v1.2.3", "a123cd", "2021-01-02", "gorelease
 	})
 }
 
-func TestUnsetMetadata(t *testing.T) {
-	is.New(t).True(semver.MustParse("v2.3.4").Equal(unsetMetadata(semver.MustParse("v2.3.4-beta+asd123"))))
-}
+func TestCmd(t *testing.T) {
+	ver := func() *semver.Version { return semver.MustParse("1.2.3-pre+123") }
+	t.Run(currentCmd.FullCommand(), func(t *testing.T) {
+		cmd := currentCmd.FullCommand()
+		t.Run("no meta", func(t *testing.T) {
+			is := is.New(t)
+			v, err := nextVersion(cmd, ver(), "v1.2.3", "", "")
+			is.NoErr(err)
+			is.Equal("1.2.3", v.String())
+		})
+		t.Run("build", func(t *testing.T) {
+			is := is.New(t)
+			v, err := nextVersion(cmd, ver(), "v1.2.3", "", "124")
+			is.NoErr(err)
+			is.Equal("1.2.3+124", v.String())
+		})
+		t.Run("prerel", func(t *testing.T) {
+			is := is.New(t)
+			v, err := nextVersion(cmd, ver(), "v1.2.3", "alpha.1", "")
+			is.NoErr(err)
+			is.Equal("1.2.3-alpha.1", v.String())
+		})
+		t.Run("all meta", func(t *testing.T) {
+			is := is.New(t)
+			v, err := nextVersion(cmd, ver(), "v1.2.3", "alpha.2", "125")
+			is.NoErr(err)
+			is.Equal("1.2.3-alpha.2+125", v.String())
+		})
+	})
 
-func TestStripPrefixReturnsVersionOnly(t *testing.T) {
-	is.New(t).True(getVersion("v2.3.4", "v", "4.5.6", "", true) == "4.5.6")
-}
+	t.Run(minorCmd.FullCommand(), func(t *testing.T) {
+		cmd := minorCmd.FullCommand()
+		t.Run("no meta", func(t *testing.T) {
+			is := is.New(t)
+			v, err := nextVersion(cmd, ver(), "v1.2.3", "", "")
+			is.NoErr(err)
+			is.Equal("1.3.0", v.String())
+		})
+		t.Run("build", func(t *testing.T) {
+			is := is.New(t)
+			v, err := nextVersion(cmd, ver(), "v1.2.3", "", "124")
+			is.NoErr(err)
+			is.Equal("1.3.0+124", v.String())
+		})
+		t.Run("prerel", func(t *testing.T) {
+			is := is.New(t)
+			v, err := nextVersion(cmd, ver(), "v1.2.3", "alpha.1", "")
+			is.NoErr(err)
+			is.Equal("1.3.0-alpha.1", v.String())
+		})
+		t.Run("all meta", func(t *testing.T) {
+			is := is.New(t)
+			v, err := nextVersion(cmd, ver(), "v1.2.3", "alpha.2", "125")
+			is.NoErr(err)
+			is.Equal("1.3.0-alpha.2+125", v.String())
+		})
+	})
+	t.Run(patchCmd.FullCommand(), func(t *testing.T) {
+		cmd := patchCmd.FullCommand()
+		t.Run("no meta", func(t *testing.T) {
+			is := is.New(t)
+			v, err := nextVersion(cmd, semver.MustParse("1.2.3"), "v1.2.3", "", "")
+			is.NoErr(err)
+			is.Equal("1.2.4", v.String())
+		})
+		t.Run("original had no meta", func(t *testing.T) {
+			is := is.New(t)
+			v, err := nextVersion(cmd, semver.MustParse("1.2.3-alpha.1+1"), "v1.2.3", "", "")
+			is.NoErr(err)
+			is.Equal("1.2.3", v.String())
+		})
+		t.Run("build", func(t *testing.T) {
+			is := is.New(t)
+			v, err := nextVersion(cmd, semver.MustParse("1.2.3"), "v1.2.3", "", "124")
+			is.NoErr(err)
+			is.Equal("1.2.4+124", v.String())
+		})
+		t.Run("prerel", func(t *testing.T) {
+			is := is.New(t)
+			v, err := nextVersion(cmd, semver.MustParse("1.2.3"), "v1.2.3", "alpha.1", "")
+			is.NoErr(err)
+			is.Equal("1.2.4-alpha.1", v.String())
+		})
+		t.Run("all meta", func(t *testing.T) {
+			is := is.New(t)
+			v, err := nextVersion(cmd, semver.MustParse("1.2.3"), "v1.2.3", "alpha.2", "125")
+			is.NoErr(err)
+			is.Equal("1.2.4-alpha.2+125", v.String())
+		})
+	})
+	t.Run(majorCmd.FullCommand(), func(t *testing.T) {
+		cmd := majorCmd.FullCommand()
+		t.Run("no meta", func(t *testing.T) {
+			is := is.New(t)
+			v, err := nextVersion(cmd, ver(), "v1.2.3", "", "")
+			is.NoErr(err)
+			is.Equal("2.0.0", v.String())
+		})
+		t.Run("build", func(t *testing.T) {
+			is := is.New(t)
+			v, err := nextVersion(cmd, ver(), "v1.2.3", "", "124")
+			is.NoErr(err)
+			is.Equal("2.0.0+124", v.String())
+		})
+		t.Run("prerel", func(t *testing.T) {
+			is := is.New(t)
+			v, err := nextVersion(cmd, ver(), "v1.2.3", "alpha.1", "")
+			is.NoErr(err)
+			is.Equal("2.0.0-alpha.1", v.String())
+		})
+		t.Run("all meta", func(t *testing.T) {
+			is := is.New(t)
+			v, err := nextVersion(cmd, ver(), "v1.2.3", "alpha.2", "125")
+			is.NoErr(err)
+			is.Equal("2.0.0-alpha.2+125", v.String())
+		})
+	})
 
-func TestStripPrefixWhenNoPrefixReturnsVersionOnly(t *testing.T) {
-	is.New(t).True(getVersion("2.3.4", "v", "4.5.6", "", true) == "4.5.6")
-}
-
-func TestNoStripPrefixReturnsPrefixAndVersion(t *testing.T) {
-	is.New(t).True(getVersion("v2.3.4", "v", "4.5.6", "", false) == "v4.5.6")
-}
-
-func TestSuffix(t *testing.T) {
-	is.New(t).True(getVersion("v2.3.4", "v", "4.5.6", "dev", false) == "v4.5.6-dev")
+	t.Run("errors", func(t *testing.T) {
+		t.Run("invalid build", func(t *testing.T) {
+			is := is.New(t)
+			_, err := nextVersion(minorCmd.FullCommand(), semver.MustParse("1.2.3"), "v1.2.3", "", "+125")
+			is.True(err != nil)
+		})
+		t.Run("invalid prerelease", func(t *testing.T) {
+			is := is.New(t)
+			_, err := nextVersion(minorCmd.FullCommand(), semver.MustParse("1.2.3"), "v1.2.3", "+aaa", "")
+			is.True(err != nil)
+		})
+	})
 }


### PR DESCRIPTION
## Breaking Change

- no more "cleaning metadata" et al, it'll act respecting semver:
  - if you are incrementing a patch from a tag with metadata, it'll just drop the metadata
  - if you are incrementing a patch with no metadata, it'll increment the patch as before
  - incrementing minors and majors always drop metadata
- if you want your new version to have some metadata, use `--pre-release` and `--build`. Those will be added to the version **after** the increments happened
- dropped a bunch of flags, replaced usage in others 


closes #88