### PR TITLE
Bug: Multiple lines on strip prefix

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ func main() {
 
 	if *stripPrefix {
 		fmt.Println(result.String())
+		return
 	}
 	fmt.Println(*prefix + result.String())
 }


### PR DESCRIPTION
Summary
=======
There is a bug in v1.10.1 that causes multiple lines to be returned if the user has passed the `--strip-prefix` flag. This will break CI/CD in downstream projects. 

Not sure if its what you envisioned but adding a simple return after the `fmt.println()` in the prefix if statement should resolve the issue. 

Testing
=======
All testing was done locally: 
Prior to fix:
```bash
$ svu --strip-prefix
0.1.0
v0.1.0
```
Post fix: 
```bash
$ svu --strip-prefix
0.1.0
```