### PR TITLE
feat: add support for calculating the next prerelease tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,28 @@ $ svu next --force-patch-increment
 v1.2.4
 ```
 
+### `svu prerelease`
+
+Increases the pre-release of the latest tag and prints it. If a `pre-release`
+identifier is passed in and it differs from the current pre-release tag that
+the identifier passed in will be used. If the current tag is not a pre-release
+tag then passing in `--pre-release` is required.
+
+> alias: `svu pr`
+
+**Examples:**
+
+```bash
+$ svu current
+v1.2.3-alpha.2+123
+
+$ svu prerelease
+v1.2.3-alpha.3
+
+$ svu minor --pre-release alpha.33 --build 243
+v1.3.0-alpha.33+243
+```
+
 ## tag mode
 
 By default `svu` will get the latest tag from the current branch. Using the `--tag-mode` flag this behaviour can be altered:

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"runtime/debug"
+	"strconv"
 	"strings"
 
 	"github.com/Masterminds/semver"
@@ -13,20 +14,28 @@ import (
 )
 
 var (
-	app                 = kingpin.New("svu", "semantic version util")
-	nextCmd             = app.Command("next", "prints the next version based on the git log").Alias("n").Default()
-	majorCmd            = app.Command("major", "new major version")
-	minorCmd            = app.Command("minor", "new minor version").Alias("m")
-	patchCmd            = app.Command("patch", "new patch version").Alias("p")
-	currentCmd          = app.Command("current", "prints current version").Alias("c")
-	pattern             = app.Flag("pattern", "limits calculations to be based on tags matching the given pattern").String()
-	prefix              = app.Flag("prefix", "set a custom prefix").Default("v").String()
-	stripPrefix         = app.Flag("strip-prefix", "strips the prefix from the tag").Default("false").Bool()
-	preRelease          = app.Flag("pre-release", "adds a pre-release suffix to the version, without the semver mandatory dash prefix").String()
-	build               = app.Flag("build", "adds a build suffix to the version, without the semver mandatory plug prefix").String()
-	directory           = app.Flag("directory", "specifies directory to filter commit messages by").Default("").String()
-	tagMode             = app.Flag("tag-mode", "determines if latest tag of the current or all branches will be used").Default("current-branch").Enum("current-branch", "all-branches")
-	forcePatchIncrement = nextCmd.Flag("force-patch-increment", "forces a patch version increment regardless of the commit message content").Default("false").Bool()
+	app           = kingpin.New("svu", "semantic version util")
+	nextCmd       = app.Command("next", "prints the next version based on the git log").Alias("n").Default()
+	majorCmd      = app.Command("major", "new major version")
+	minorCmd      = app.Command("minor", "new minor version").Alias("m")
+	patchCmd      = app.Command("patch", "new patch version").Alias("p")
+	currentCmd    = app.Command("current", "prints current version").Alias("c")
+	preReleaseCmd = app.Command("prerelease", "new pre release version based on the next version calculated from git log").
+			Alias("pr")
+	pattern     = app.Flag("pattern", "limits calculations to be based on tags matching the given pattern").String()
+	prefix      = app.Flag("prefix", "set a custom prefix").Default("v").String()
+	stripPrefix = app.Flag("strip-prefix", "strips the prefix from the tag").Default("false").Bool()
+	preRelease  = app.Flag("pre-release", "adds a pre-release suffix to the version, without the semver mandatory dash prefix").
+			String()
+	build = app.Flag("build", "adds a build suffix to the version, without the semver mandatory plug prefix").
+		String()
+	directory = app.Flag("directory", "specifies directory to filter commit messages by").Default("").String()
+	tagMode   = app.Flag("tag-mode", "determines if latest tag of the current or all branches will be used").
+			Default("current-branch").
+			Enum("current-branch", "all-branches")
+	forcePatchIncrement = nextCmd.Flag("force-patch-increment", "forces a patch version increment regardless of the commit message content").
+				Default("false").
+				Bool()
 )
 
 func main() {
@@ -82,15 +91,68 @@ func nextVersion(cmd string, current *semver.Version, tag, preRelease, build str
 	}
 
 	var err error
-	result, err = result.SetPrerelease(preRelease)
-	if err != nil {
-		return result, err
+	if cmd == preReleaseCmd.FullCommand() {
+		next := findNext(current, tag, *directory)
+		result, err = nextPreRelease(current, &next, preRelease)
+		if err != nil {
+			return result, err
+		}
+	} else {
+		result, err = result.SetPrerelease(preRelease)
+		if err != nil {
+			return result, err
+		}
 	}
+
 	result, err = result.SetMetadata(build)
 	if err != nil {
 		return result, err
 	}
 	return result, nil
+}
+
+func nextPreRelease(current, next *semver.Version, preRelease string) (semver.Version, error) {
+	suffix := ""
+	if preRelease != "" {
+		// Check if the suffix already contains a version number, if it does assume the user wants to explicitly set the version so use that
+		if _, err := strconv.Atoi(suffix); err == nil {
+			return current.SetPrerelease(suffix)
+		}
+		suffix = preRelease
+
+		// Check if the prerelease suffix is the same as the current prerelease
+		preSuffix := strings.Split(current.Prerelease(), ".")[0]
+		if preSuffix == preRelease {
+			suffix = current.Prerelease()
+		}
+	} else if current.Prerelease() != "" {
+		suffix = current.Prerelease()
+	} else {
+		return *current, fmt.Errorf(
+			"--pre-release suffix is required to calculate next pre-release version as suffix could not be determined from current version: %s",
+			current.String(),
+		)
+	}
+
+	splitSuffix := strings.Split(suffix, ".")
+	preReleaseName := splitSuffix[0]
+	preReleaseVersion := 0
+
+	currentWithoutPreRelease, _ := current.SetPrerelease("")
+
+	if !next.GreaterThan(&currentWithoutPreRelease) {
+		preReleaseVersion = -1
+		if len(splitSuffix) == 2 {
+			preReleaseName = splitSuffix[0]
+			preReleaseVersion, _ = strconv.Atoi(splitSuffix[1])
+		} else if len(splitSuffix) > 2 {
+			preReleaseName = splitSuffix[len(splitSuffix)-1]
+		}
+
+		preReleaseVersion++
+	}
+
+	return next.SetPrerelease(fmt.Sprintf("%s.%d", preReleaseName, preReleaseVersion))
 }
 
 func getCurrentVersion(tag string) (*semver.Version, error) {


### PR DESCRIPTION
Adds a `prerelease` command which will increment the prerelease version based on what the next version will be from the git log, taking into account the current prerelease version from the latest tag.

If `--pre-release` is passed in and contains a number then this will be used and all calculations will be skipped. If `--pre-release` is passed in and it matches the pre-release suffix of the current tag then calculations will still occur.

Example:
```bash
$ svu current
v1.2.3-alpha.2+123

$ svu prerelease
v1.2.3-alpha.3

$ svu minor --pre-release alpha.33 --build 243
v1.3.0-alpha.33+243
```

Fixes: #112 