### PR TITLE
fix: pre-release flag only worked on the pr command

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ var (
 	currentCmd    = app.Command("current", "prints current version").Alias("c")
 	preReleaseCmd = app.Command("prerelease", "new pre release version based on the next version calculated from git log").
 			Alias("pr")
-	preRelease = preReleaseCmd.Flag("pre-release", "adds a pre-release suffix to the version, without the semver mandatory dash prefix").
+	preRelease  = app.Flag("pre-release", "adds a pre-release suffix to the version, without the semver mandatory dash prefix").
 			String()
 	pattern     = app.Flag("pattern", "limits calculations to be based on tags matching the given pattern").String()
 	prefix      = app.Flag("prefix", "set a custom prefix").Default("v").String()


### PR DESCRIPTION
fixes the examples from the README that do not work.

```shell
$ svu patch --pre-release alpha.3 --build 243
v1.2.3-alpha.3+243
$ svu minor --pre-release alpha.3 --build 243
v1.3.0-alpha.3+243
$ svu major --pre-release alpha.3 --build 243
v2.0.0-alpha.3+243
```