### PR TITLE
feat: try to infer sub-package tag

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -22,6 +22,12 @@ func IsRepo() bool {
 	return err == nil && strings.TrimSpace(out) == "true"
 }
 
+// Root returns the root of the git repository
+func Root() (string, error) {
+	out, err := run("rev-parse", "--show-toplevel")
+	return strings.TrimSpace(out), err
+}
+
 func getAllTags(args ...string) ([]string, error) {
 	tags, err := run(append([]string{"-c", "versionsort.suffix=-", "tag", "--sort=-version:refname"}, args...)...)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -3,9 +3,12 @@ package main
 import (
 	"fmt"
 	"os"
+	"path"
 	"runtime/debug"
+	"strings"
 
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/caarlos0/svu/v2/internal/git"
 	"github.com/caarlos0/svu/v2/internal/svu"
 )
 
@@ -18,10 +21,10 @@ var (
 	currentCmd    = app.Command("current", "prints current version").Alias("c")
 	preReleaseCmd = app.Command("prerelease", "new pre release version based on the next version calculated from git log").
 			Alias("pr")
-	preRelease  = app.Flag("pre-release", "adds a pre-release suffix to the version, without the semver mandatory dash prefix").
+	preRelease = app.Flag("pre-release", "adds a pre-release suffix to the version, without the semver mandatory dash prefix").
 			String()
-	pattern     = app.Flag("pattern", "limits calculations to be based on tags matching the given pattern").String()
-	prefix      = app.Flag("prefix", "set a custom prefix").Default("v").String()
+	pattern     = app.Flag("pattern", "limits calculations to be based on tags matching the given pattern").Default(defaults("pattern")).String()
+	prefix      = app.Flag("prefix", "set a custom prefix").Default(defaults("prefix")).String()
 	stripPrefix = app.Flag("strip-prefix", "strips the prefix from the tag").Default("false").Bool()
 	build       = app.Flag("build", "adds a build suffix to the version, without the semver mandatory plug prefix").
 			String()
@@ -36,6 +39,29 @@ var (
 					Default("false").
 					Bool()
 )
+
+func defaults(flag string) string {
+	var def, pat string
+	switch flag {
+	case "prefix":
+		def, pat = "v", "v"
+	case "pattern":
+		def, pat = "", "*"
+	default:
+		return ""
+	}
+
+	cwd, wdErr := os.Getwd()
+	gitRoot, grErr := git.Root()
+	if wdErr == nil && grErr == nil && cwd != gitRoot {
+		prefix := strings.TrimPrefix(cwd, gitRoot)
+		prefix = strings.TrimPrefix(prefix, string(os.PathSeparator))
+		prefix = strings.TrimSuffix(prefix, string(os.PathSeparator))
+		return path.Join(prefix, pat)
+	}
+
+	return def
+}
 
 func main() {
 	app.Author("Carlos Alexandro Becker <carlos@becker.software>")


### PR DESCRIPTION
This adds support for inferring a sub-package version by trying to predict the sub-package tag using the current directory and Git root path.

For example, running `svu` in a Go mono-repository with multiple packages won't return the correct tag since it won't be able to parse the latest tag `ansi/v0.1.2`.

This PR initializes the `--prefix` and `--pattern` when the current directory doesn't match the Git root making `svu` work without the need to specify `svu --prefix="ansi/v" --pattern="ansi/*" ...`.

P.S. maybe there's a cleaner way of doing so 🤔

Previously I had this little shell func
```sh
function get-next-version() {
  root=$(git rev-parse --show-toplevel)
  if [ "$PWD" != "$root" ]; then
    local prefix=$(echo -n "$PWD" | sed "s|$root/||g")
    svu --prefix="$prefix/v" --pattern="$prefix/*" "$@"
  else
    svu "$@"
  fi
}
```