### PR TITLE
fix: normalise path separators on Windows to fix sub-package tags

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"runtime/debug"
 	"strings"
 
@@ -53,11 +54,18 @@ func defaults(flag string) string {
 
 	cwd, wdErr := os.Getwd()
 	gitRoot, grErr := git.Root()
-	if wdErr == nil && grErr == nil && cwd != gitRoot {
-		prefix := strings.TrimPrefix(cwd, gitRoot)
-		prefix = strings.TrimPrefix(prefix, string(os.PathSeparator))
-		prefix = strings.TrimSuffix(prefix, string(os.PathSeparator))
-		return path.Join(prefix, pat)
+
+	if wdErr == nil && grErr == nil {
+
+		cwd = filepath.Clean(cwd)
+		gitRoot = filepath.Clean(gitRoot)
+
+		if cwd != gitRoot {
+			prefix := strings.TrimPrefix(cwd, gitRoot)
+			prefix = strings.TrimPrefix(prefix, string(os.PathSeparator))
+			prefix = strings.TrimSuffix(prefix, string(os.PathSeparator))
+			return path.Join(prefix, pat)
+		}
 	}
 
 	return def


### PR DESCRIPTION
The git cli and the go os library return representations of the same path using different path separators, so the comparison used here returned false, and the absolute path of the repo was set as the default for the pattern arg.

e.g.:
```
> git rev-parse --show-toplevel
C:/Users/Doug/Code/myrepo
```
```
os.getWd()
C:\\Users\\Doug\\Code\\myrepo
```
Using filepath.Clean() on both paths before using them normalises the slashes to a single `\`

Fixes #164 