### PR TITLE
feat: handle log line by line

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -59,12 +59,16 @@ func DescribeTag(tagMode string, pattern string) (string, error) {
 	return "", fmt.Errorf("no tags match '%s'", pattern)
 }
 
-func Changelog(tag string, dir string) (string, error) {
+func Changelog(tag string, dir string) ([]string, error) {
 	if tag == "" {
 		return gitLog(dir, "HEAD")
 	} else {
 		return gitLog(dir, fmt.Sprintf("tags/%s..HEAD", tag))
 	}
+}
+
+func Format(ref string) (string, error) {
+	return run("log", "--format=%B", "-n1", ref)
 }
 
 func run(args ...string) (string, error) {
@@ -81,11 +85,15 @@ func run(args ...string) (string, error) {
 	return string(bts), nil
 }
 
-func gitLog(dir string, refs ...string) (string, error) {
-	args := []string{"log", "--no-decorate", "--no-color"}
+func gitLog(dir string, refs ...string) ([]string, error) {
+	args := []string{"log", "--no-decorate", "--no-color", "--oneline"}
 	args = append(args, refs...)
 	if dir != "" {
 		args = append(args, "--", dir)
 	}
-	return run(args...)
+	s, err := run(args...)
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(s, "\n"), nil
 }

--- a/internal/svu/svu_test.go
+++ b/internal/svu/svu_test.go
@@ -48,6 +48,10 @@ func TestIsFeature(t *testing.T) {
 		"fix: foo",
 		"chore: foo",
 		"docs: lalala",
+		"ci: foo",
+		"test: foo",
+		"Merge remote-tracking branch 'origin/main'",
+		"refactor: foo bar",
 	} {
 		t.Run(log, func(t *testing.T) {
 			is.New(t).True(!isFeature(log)) // should NOT be a minor change


### PR DESCRIPTION
this can help prevent dependabot commits triggering feat changes because their msg body contains the changelog of the dependency itself.

BREAKING CHANGE: this might break someone.