### PR TITLE
feat: allows for multiple directory options

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -59,11 +59,11 @@ func DescribeTag(tagMode string, pattern string) (string, error) {
 	return "", fmt.Errorf("no tags match '%s'", pattern)
 }
 
-func Changelog(tag string, dir string) (string, error) {
+func Changelog(tag string, dirs ...string) (string, error) {
 	if tag == "" {
-		return gitLog(dir, "HEAD")
+		return gitLog(dirs, "HEAD")
 	} else {
-		return gitLog(dir, fmt.Sprintf("tags/%s..HEAD", tag))
+		return gitLog(dirs, fmt.Sprintf("tags/%s..HEAD", tag))
 	}
 }
 
@@ -81,11 +81,14 @@ func run(args ...string) (string, error) {
 	return string(bts), nil
 }
 
-func gitLog(dir string, refs ...string) (string, error) {
+func gitLog(dirs []string, refs ...string) (string, error) {
 	args := []string{"log", "--no-decorate", "--no-color"}
 	args = append(args, refs...)
-	if dir != "" {
-		args = append(args, "--", dir)
+	// dirs was changed from string to []string, so we handle the case where a single empty string is passed for
+	// backwards compatibility
+	if len(dirs) > 1 || (len(dirs) == 1 && dirs[0] != "") {
+		args = append(args, "--")
+		args = append(args, dirs...)
 	}
 	return run(args...)
 }

--- a/internal/svu/svu.go
+++ b/internal/svu/svu.go
@@ -33,7 +33,7 @@ type Options struct {
 	StripPrefix               bool
 	PreRelease                string
 	Build                     string
-	Directory                 string
+	Directories               []string
 	TagMode                   string
 	ForcePatchIncrement       bool
 	PreventMajorIncrementOnV0 bool
@@ -56,7 +56,7 @@ func Version(opts Options) (string, error) {
 		tag,
 		opts.PreRelease,
 		opts.Build,
-		opts.Directory,
+		opts.Directories,
 		opts.PreventMajorIncrementOnV0,
 		opts.ForcePatchIncrement,
 	)
@@ -70,7 +70,7 @@ func Version(opts Options) (string, error) {
 	return opts.Prefix + result.String(), nil
 }
 
-func nextVersion(cmd string, current *semver.Version, tag, preRelease, build, directory string, preventMajorIncrementOnV0, forcePatchIncrement bool) (semver.Version, error) {
+func nextVersion(cmd string, current *semver.Version, tag, preRelease, build string, directories []string, preventMajorIncrementOnV0, forcePatchIncrement bool) (semver.Version, error) {
 	if cmd == CurrentCmd {
 		return *current, nil
 	}
@@ -91,7 +91,7 @@ func nextVersion(cmd string, current *semver.Version, tag, preRelease, build, di
 	var err error
 	switch cmd {
 	case NextCmd, PreReleaseCmd:
-		result, err = findNextWithGitLog(current, tag, directory, preventMajorIncrementOnV0, forcePatchIncrement)
+		result, err = findNextWithGitLog(current, tag, directories, preventMajorIncrementOnV0, forcePatchIncrement)
 	case MajorCmd:
 		result = current.IncMajor()
 	case MinorCmd:
@@ -181,8 +181,8 @@ func getCurrentVersion(tag, prefix string) (*semver.Version, error) {
 	return current, err
 }
 
-func findNextWithGitLog(current *semver.Version, tag string, directory string, preventMajorIncrementOnV0, forcePatchIncrement bool) (semver.Version, error) {
-	log, err := git.Changelog(tag, directory)
+func findNextWithGitLog(current *semver.Version, tag string, directories []string, preventMajorIncrementOnV0, forcePatchIncrement bool) (semver.Version, error) {
+	log, err := git.Changelog(tag, directories...)
 	if err != nil {
 		return semver.Version{}, fmt.Errorf("failed to get changelog: %w", err)
 	}

--- a/internal/svu/svu_test.go
+++ b/internal/svu/svu_test.go
@@ -107,13 +107,13 @@ func TestCmd(t *testing.T) {
 		cmd := CurrentCmd
 		t.Run("version has meta", func(t *testing.T) {
 			is := is.New(t)
-			v, err := nextVersion(cmd, ver(), "v1.2.3", "", "", "", false, false)
+			v, err := nextVersion(cmd, ver(), "v1.2.3", "", "", nil, false, false)
 			is.NoErr(err)
 			is.Equal("1.2.3-pre+123", v.String())
 		})
 		t.Run("version is clean", func(t *testing.T) {
 			is := is.New(t)
-			v, err := nextVersion(cmd, semver.MustParse("v1.2.3"), "v1.2.3", "doesnt matter", "nope", "", false, true)
+			v, err := nextVersion(cmd, semver.MustParse("v1.2.3"), "v1.2.3", "doesnt matter", "nope", nil, false, true)
 			is.NoErr(err)
 			is.Equal("1.2.3", v.String())
 		})
@@ -123,25 +123,25 @@ func TestCmd(t *testing.T) {
 		cmd := MinorCmd
 		t.Run("no meta", func(t *testing.T) {
 			is := is.New(t)
-			v, err := nextVersion(cmd, ver(), "v1.2.3", "", "", "", false, false)
+			v, err := nextVersion(cmd, ver(), "v1.2.3", "", "", nil, false, false)
 			is.NoErr(err)
 			is.Equal("1.3.0", v.String())
 		})
 		t.Run("build", func(t *testing.T) {
 			is := is.New(t)
-			v, err := nextVersion(cmd, ver(), "v1.2.3", "", "124", "", false, false)
+			v, err := nextVersion(cmd, ver(), "v1.2.3", "", "124", nil, false, false)
 			is.NoErr(err)
 			is.Equal("1.3.0+124", v.String())
 		})
 		t.Run("prerel", func(t *testing.T) {
 			is := is.New(t)
-			v, err := nextVersion(cmd, ver(), "v1.2.3", "alpha.1", "", "", false, false)
+			v, err := nextVersion(cmd, ver(), "v1.2.3", "alpha.1", "", nil, false, false)
 			is.NoErr(err)
 			is.Equal("1.3.0-alpha.1", v.String())
 		})
 		t.Run("all meta", func(t *testing.T) {
 			is := is.New(t)
-			v, err := nextVersion(cmd, ver(), "v1.2.3", "alpha.2", "125", "", false, false)
+			v, err := nextVersion(cmd, ver(), "v1.2.3", "alpha.2", "125", nil, false, false)
 			is.NoErr(err)
 			is.Equal("1.3.0-alpha.2+125", v.String())
 		})
@@ -151,49 +151,49 @@ func TestCmd(t *testing.T) {
 		cmd := PatchCmd
 		t.Run("no meta", func(t *testing.T) {
 			is := is.New(t)
-			v, err := nextVersion(cmd, semver.MustParse("1.2.3"), "v1.2.3", "", "", "", false, false)
+			v, err := nextVersion(cmd, semver.MustParse("1.2.3"), "v1.2.3", "", "", nil, false, false)
 			is.NoErr(err)
 			is.Equal("1.2.4", v.String())
 		})
 		t.Run("previous had meta", func(t *testing.T) {
 			is := is.New(t)
-			v, err := nextVersion(cmd, semver.MustParse("1.2.3-alpha.1+1"), "v1.2.3", "", "", "", false, false)
+			v, err := nextVersion(cmd, semver.MustParse("1.2.3-alpha.1+1"), "v1.2.3", "", "", nil, false, false)
 			is.NoErr(err)
 			is.Equal("1.2.3", v.String())
 		})
 		t.Run("previous had meta, force", func(t *testing.T) {
 			is := is.New(t)
-			v, err := nextVersion(cmd, semver.MustParse("1.2.3-alpha.1+1"), "v1.2.3", "", "", "", false, true)
+			v, err := nextVersion(cmd, semver.MustParse("1.2.3-alpha.1+1"), "v1.2.3", "", "", nil, false, true)
 			is.NoErr(err)
 			is.Equal("1.2.4", v.String())
 		})
 		t.Run("previous had meta, force, add meta", func(t *testing.T) {
 			is := is.New(t)
-			v, err := nextVersion(cmd, semver.MustParse("1.2.3-alpha.1+1"), "v1.2.3-alpha.1+1", "alpha.2", "10", "", false, true)
+			v, err := nextVersion(cmd, semver.MustParse("1.2.3-alpha.1+1"), "v1.2.3-alpha.1+1", "alpha.2", "10", nil, false, true)
 			is.NoErr(err)
 			is.Equal("1.2.4-alpha.2+10", v.String())
 		})
 		t.Run("previous had meta, change it", func(t *testing.T) {
 			is := is.New(t)
-			v, err := nextVersion(cmd, semver.MustParse("1.2.3-alpha.1+1"), "v1.2.3-alpha.1+1", "alpha.2", "10", "", false, false)
+			v, err := nextVersion(cmd, semver.MustParse("1.2.3-alpha.1+1"), "v1.2.3-alpha.1+1", "alpha.2", "10", nil, false, false)
 			is.NoErr(err)
 			is.Equal("1.2.3-alpha.2+10", v.String())
 		})
 		t.Run("build", func(t *testing.T) {
 			is := is.New(t)
-			v, err := nextVersion(cmd, semver.MustParse("1.2.3"), "v1.2.3", "", "124", "", false, false)
+			v, err := nextVersion(cmd, semver.MustParse("1.2.3"), "v1.2.3", "", "124", nil, false, false)
 			is.NoErr(err)
 			is.Equal("1.2.4+124", v.String())
 		})
 		t.Run("prerel", func(t *testing.T) {
 			is := is.New(t)
-			v, err := nextVersion(cmd, semver.MustParse("1.2.3"), "v1.2.3", "alpha.1", "", "", false, false)
+			v, err := nextVersion(cmd, semver.MustParse("1.2.3"), "v1.2.3", "alpha.1", "", nil, false, false)
 			is.NoErr(err)
 			is.Equal("1.2.4-alpha.1", v.String())
 		})
 		t.Run("all meta", func(t *testing.T) {
 			is := is.New(t)
-			v, err := nextVersion(cmd, semver.MustParse("1.2.3"), "v1.2.3", "alpha.2", "125", "", false, false)
+			v, err := nextVersion(cmd, semver.MustParse("1.2.3"), "v1.2.3", "alpha.2", "125", nil, false, false)
 			is.NoErr(err)
 			is.Equal("1.2.4-alpha.2+125", v.String())
 		})
@@ -203,25 +203,25 @@ func TestCmd(t *testing.T) {
 		cmd := MajorCmd
 		t.Run("no meta", func(t *testing.T) {
 			is := is.New(t)
-			v, err := nextVersion(cmd, ver(), "v1.2.3", "", "", "", false, false)
+			v, err := nextVersion(cmd, ver(), "v1.2.3", "", "", nil, false, false)
 			is.NoErr(err)
 			is.Equal("2.0.0", v.String())
 		})
 		t.Run("build", func(t *testing.T) {
 			is := is.New(t)
-			v, err := nextVersion(cmd, ver(), "v1.2.3", "", "124", "", false, false)
+			v, err := nextVersion(cmd, ver(), "v1.2.3", "", "124", nil, false, false)
 			is.NoErr(err)
 			is.Equal("2.0.0+124", v.String())
 		})
 		t.Run("prerel", func(t *testing.T) {
 			is := is.New(t)
-			v, err := nextVersion(cmd, ver(), "v1.2.3", "alpha.1", "", "", false, false)
+			v, err := nextVersion(cmd, ver(), "v1.2.3", "alpha.1", "", nil, false, false)
 			is.NoErr(err)
 			is.Equal("2.0.0-alpha.1", v.String())
 		})
 		t.Run("all meta", func(t *testing.T) {
 			is := is.New(t)
-			v, err := nextVersion(cmd, ver(), "v1.2.3", "alpha.2", "125", "", false, false)
+			v, err := nextVersion(cmd, ver(), "v1.2.3", "alpha.2", "125", nil, false, false)
 			is.NoErr(err)
 			is.Equal("2.0.0-alpha.2+125", v.String())
 		})
@@ -230,12 +230,12 @@ func TestCmd(t *testing.T) {
 	t.Run("errors", func(t *testing.T) {
 		t.Run("invalid build", func(t *testing.T) {
 			is := is.New(t)
-			_, err := nextVersion(MinorCmd, semver.MustParse("1.2.3"), "v1.2.3", "", "+125", "", false, false)
+			_, err := nextVersion(MinorCmd, semver.MustParse("1.2.3"), "v1.2.3", "", "+125", nil, false, false)
 			is.True(err != nil)
 		})
 		t.Run("invalid prerelease", func(t *testing.T) {
 			is := is.New(t)
-			_, err := nextVersion(MinorCmd, semver.MustParse("1.2.3"), "v1.2.3", "+aaa", "", "", false, false)
+			_, err := nextVersion(MinorCmd, semver.MustParse("1.2.3"), "v1.2.3", "+aaa", "", nil, false, false)
 			is.True(err != nil)
 		})
 	})

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ var (
 	stripPrefix = app.Flag("strip-prefix", "strips the prefix from the tag").Default("false").Bool()
 	build       = app.Flag("build", "adds a build suffix to the version, without the semver mandatory plug prefix").
 			String()
-	directory = app.Flag("directory", "specifies directory to filter commit messages by").Default("").String()
+	directories = app.Flag("directory", "specifies directory to filter commit messages by").Default("").Strings()
 	tagMode   = app.Flag("tag-mode", "determines if latest tag of the current or all branches will be used").
 			Default("current-branch").
 			Enum("current-branch", "all-branches")
@@ -51,7 +51,7 @@ func main() {
 		StripPrefix:               *stripPrefix,
 		PreRelease:                *preRelease,
 		Build:                     *build,
-		Directory:                 *directory,
+		Directories:               *directories,
 		TagMode:                   *tagMode,
 		ForcePatchIncrement:       *forcePatchIncrement,
 		PreventMajorIncrementOnV0: *preventMajorIncrementOnV0,

--- a/pkg/svu/svu.go
+++ b/pkg/svu/svu.go
@@ -74,7 +74,7 @@ func WithBuild(build string) option {
 
 func WithDirectory(directory string) option {
 	return func(o *svu.Options) {
-		o.Directory = directory
+		o.Directories = append(o.Directories, directory)
 	}
 }
 


### PR DESCRIPTION
This PR allows users to supply multiple directory options as described in Issue https://github.com/caarlos0/svu/issues/186. 

In order to minimize API changes and make this backwards compatible we keep the existing `WithDirectory` and `--directory` args and allow them to be supplied multiple times. For example:

 `svu.Next(svu.WithDirectory("go.mod"), svu.WithDirectory("cmd/app"))`
 `svu next --directory go.mod --directory cmd/app`
 
 Previous users may have been passing an empty string so we check this as a special case in `gitLog`.