### PR TITLE
Fix typo in PKGBUILD

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,6 +51,6 @@ aurs:
       mkdir -p "${pkgdir}/usr/share/bash-completion/completions/"
       mkdir -p "${pkgdir}/usr/share/zsh/site-functions/"
       mkdir -p "${pkgdir}/usr/share/fish/vendor_completions.d/"
-      install -Dm644 "./completions/svu.bash" "${pkgdir}/usr/share/bash-completion/completions/svu
+      install -Dm644 "./completions/svu.bash" "${pkgdir}/usr/share/bash-completion/completions/svu"
       install -Dm644 "./completions/svu.zsh" "${pkgdir}/usr/share/zsh/site-functions/_svu"
       install -Dm644 "./completions/svu.fish" "${pkgdir}/usr/share/fish/vendor_completions.d/svu.fish"


### PR DESCRIPTION
Hi 👋🏻 !

This PR adds a missing double quote that causes a build failure when installing and building the latest version of `svu-bin` from AUR:

```bash
git clone https://aur.archlinux.org/svu-bin.git
cd svu-bin/
makepkg -si
```

ends in the following error:
```
svu-bin/PKGBUILD: line 32: unexpected EOF while looking for matching `"'
==> ERROR: Failed to source svu-bin/PKGBUILD
```

A GitHub action step could possibly be added to run the above steps in e.g. an Arch container?

Thanks!