### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0


### PR DESCRIPTION
Potential fix for [https://github.com/caarlos0/svu/security/code-scanning/1](https://github.com/caarlos0/svu/security/code-scanning/1)

To resolve this, we should add an explicit `permissions` block to the `build` job in `.github/workflows/build.yml`, specifying the minimum required permissions for this job. In this case, as the job only checks out code and runs Go commands, it does not require write permissions — only read access to repository contents is needed. Therefore, add

```yaml
permissions:
  contents: read
```

as a block under the `build` job (line 13), and above the `steps` key. No imports or other code changes are needed, and no functionality outside the workflow file should be modified.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
