### PR TITLE
fix: Ensure --always doesn't increment twice

### DIFF
--- a/internal/svu/svu.go
+++ b/internal/svu/svu.go
@@ -91,12 +91,6 @@ func nextVersion(
 		return *current, nil
 	}
 
-	if opts.Always {
-		c, _ := current.SetMetadata("")
-		c, _ = c.SetPrerelease("")
-		current = &c
-	}
-
 	var result semver.Version
 	var err error
 	switch opts.Action {
@@ -111,6 +105,12 @@ func nextVersion(
 	}
 	if err != nil {
 		return result, err
+	}
+
+	if opts.Always {
+		c, _ := current.SetMetadata("")
+		c, _ = c.SetPrerelease("")
+		current = &c
 	}
 
 	if opts.Action == PreRelease {

--- a/internal/svu/svu_test.go
+++ b/internal/svu/svu_test.go
@@ -190,7 +190,7 @@ func TestCmd(t *testing.T) {
 				Always: true,
 			})
 			require.NoError(t, err)
-			require.Equal(t, "1.2.4", v.String())
+			require.Equal(t, "1.2.3", v.String())
 		})
 		t.Run("previous had meta + always, add meta", func(t *testing.T) {
 			v, err := nextVersion(semver.MustParse("1.2.3-alpha.1+1"), "v1.2.3-alpha.1+1", Options{
@@ -201,7 +201,7 @@ func TestCmd(t *testing.T) {
 				Metadata:   "10",
 			})
 			require.NoError(t, err)
-			require.Equal(t, "1.2.4-alpha.2+10", v.String())
+			require.Equal(t, "1.2.3-alpha.2+10", v.String())
 		})
 		t.Run("previous had meta, change it", func(t *testing.T) {
 			v, err := nextVersion(semver.MustParse("1.2.3-alpha.1+1"), "v1.2.3-alpha.1+1", Options{


### PR DESCRIPTION
This can happen like so:
- Have a `v1.2.3-alpha` (which is a prerelease)
- Run `svu next --always`
  - In `nextVersion`, this follows the `opts.Always` branch, and strips the metadata+prerelease info, deriving `v1.2.3`.
  - We call `findNext`, which follows the `opts.Always` branch again, and increments the patch to `v1.2.4`.

However, `IncPatch` (and family) already handle the case where we have a prerelease/metadata set. We don't need to strip it before then (but I moved the check just till after, in case some action falls through, etc).

We need to update the tests though - the behavior there seems wrong to me, the behavior of `--always` should be to bump *at least once*, not potentially sometimes twice.