### PR TITLE
chore(ci): use actions/attest instead of actions/attest-build-provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           AUR_KEY: ${{ secrets.AUR_KEY }}
-      - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+      - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         with:
           subject-checksums: ./dist/checksums.txt


### PR DESCRIPTION
https://github.com/actions/attest-build-provenance#usage

> As of version 4, actions/attest-build-provenance is simply a wrapper on top of actions/attest.