### PR TITLE
docs: remove starchart.cc embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,6 @@ Or download one from the [releases tab](https://github.com/caarlos0/svu/releases
 
 </details>
 
-## stargazers over time
-
-[![Stargazers over time](https://starchart.cc/caarlos0/svu.svg?variant=adaptive)](https://starchart.cc/caarlos0/svu)
-
 [Semver]: https://semver.org
 
 ---


### PR DESCRIPTION
`starchart.cc` is rate limited and rendering a broken image in the README, so this removes the embed and its (now-empty) stargazers section.

Refs: https://github.com/caarlos0/starcharts/issues/260
